### PR TITLE
fix package building in mb2

### DIFF
--- a/rpm/virtualbox.spec
+++ b/rpm/virtualbox.spec
@@ -130,7 +130,7 @@ VirtualBox guest addition tools.
 # version may contain a +, and virtualbox refuses to build with that in the path
 # so change the buildsubdir to be different from what's in the tarfile
 %setup -q -n %{name} -c
-mv %{name}-%{version}/%{name}/* .
+cd %{name}/
 
 # use the packaged kBuild rather than the bundled one
 rm -rf kBuild


### PR DESCRIPTION
currently the package seems to be a tar_git project, but doesn't build properly in mb2 (PlatformSDK) while building fine in OBS.

This may break the OBS build though: The difference is that the OBS build pulls in a tar.gz archive of virtualbox and extracts it, which may result in a different directory structure than the one in this tar_git repo.

[ ] unify paths between OBS and mb2 build