### PR TITLE
fixing reported required kBuild version

### DIFF
--- a/virtualbox/Config.kmk
+++ b/virtualbox/Config.kmk
@@ -167,7 +167,7 @@ if  $(KBUILD_VERSION_MAJOR) == 0 \
  if $(KMK_REVISION) >= 2689
   # OK.
  else
-  $(error You must update kBuild! Requires kBuild revision 2577 or later, found $(KMK_REVISION) ($(KBUILD_VERSION)))
+  $(error You must update kBuild! Requires kBuild revision 2689 or later, found $(KMK_REVISION) ($(KBUILD_VERSION)))
  endif
 else
  $(error You must update kBuild! Requires 0.1.999 or later, found $(KBUILD_VERSION))

--- a/virtualbox/Config.kmk
+++ b/virtualbox/Config.kmk
@@ -160,14 +160,15 @@ VBOX_PATH_PACKAGES    = $(patsubst %/,%,$(PATH_STAGE)/$(INST_PACKAGES))
 .DELETE_ON_ERROR:
 
 # Notify about important kBuild updates.
+VBOX_MIN_KBUILD_KMK_REVISION := 2689
 if  $(KBUILD_VERSION_MAJOR) == 0 \
  && (   $(KBUILD_VERSION_MINOR) >= 2 \
      || (   $(KBUILD_VERSION_MINOR) == 1 \
          && $(KBUILD_VERSION_PATCH) >= 999))
- if $(KMK_REVISION) >= 2689
+ if $(KMK_REVISION) >= $(VBOX_MIN_KBUILD_KMK_REVISION)
   # OK.
  else
-  $(error You must update kBuild! Requires kBuild revision 2689 or later, found $(KMK_REVISION) ($(KBUILD_VERSION)))
+  $(error You must update kBuild! Requires kBuild revision $(VBOX_MIN_KBUILD_KMK_REVISION) or later, found $(KMK_REVISION) ($(KBUILD_VERSION)))
  endif
 else
  $(error You must update kBuild! Requires 0.1.999 or later, found $(KBUILD_VERSION))


### PR DESCRIPTION
- kmk checks for a minimum kBuild version to be used. The error string
  still contained an older version than the one that was checked for

this issue is very small, but still confusing as wrong error messages are not helpful at all.