### PR TITLE
[virtualbox] Use full path when sourcing env.sh. JB#51809

### DIFF
--- a/rpm/virtualbox.spec
+++ b/rpm/virtualbox.spec
@@ -169,7 +169,7 @@ echo "SED = $(readlink -f ./kmk_sed)"  >> LocalConfig.kmk
 	--enable-webservice
 
 # configure actually warns we should source env.sh (which seems like it could influence the build...)
-source env.sh
+source ./env.sh
 
 #
 #  	VBOX_PATH_PACKAGE_DOCS set propper path for link to pdf in .desktop file


### PR DESCRIPTION
After bash 4.0, source no longer searches pwd in posix mode