### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/virtualbox.spec
+++ b/rpm/virtualbox.spec
@@ -60,7 +60,7 @@ BuildRequires:  udev
 BuildRequires:  yasm
 #BuildRequires:  zlib-devel-static
 # and just for the macro:
-BuildRequires:   systemd
+BuildRequires:   pkgconfig(systemd)
 
 Version:        5.2.30
 Release:        1


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.